### PR TITLE
python 3.8 futures

### DIFF
--- a/lib/streamlit/hello.py
+++ b/lib/streamlit/hello.py
@@ -12,10 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import division, unicode_literals
 
 """A "Hello World" app."""
-
-from __future__ import division, unicode_literals
 
 import streamlit as st
 from streamlit.logger import get_logger


### PR DESCRIPTION
this makes hello work on python 3.8, there are many errors preventing the other demos to run but you can at least get the  fractals demo running.